### PR TITLE
Updated Dependencies to latest version + Minor Refactoring.

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -1,9 +1,10 @@
-﻿using Serilog;
+﻿using System.Text;
+using Serilog;
 using Serilog.Sinks.Discord;
 
-// SET THE ENVIROMENT VARIABLES BEFORE RUNNING THE DEMO
+// SET THE ENVIRONMENT VARIABLES BEFORE RUNNING THE DEMO
 // See https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks on how to get the webhook id and token
-// Format: https://discord.com/api/webhooks/<WEBHOOk_ID>/<WEBHOOK_TOKEN>
+// Format: https://discord.com/api/webhooks/<WEBHOOK_ID>/<WEBHOOK_TOKEN>
 var webhookId = ulong.Parse(Environment.GetEnvironmentVariable("WEBHOOK_ID")!);
 var webhookToken = Environment.GetEnvironmentVariable("WEBHOOK_TOKEN")!;
 Log.Logger = new LoggerConfiguration()
@@ -18,46 +19,46 @@ Log.Information("Hello, world!");
 
 
 /* Different log levels */
-// Log.Verbose("This is a Verbose message");
-// Log.Debug("This is a Debug message");
-// Log.Information("This is an Information message");
-// Log.Warning("This is a Warning message");
-// Log.Error("This is an Error message");
-// Log.Fatal("This is a Fatal message");
+Log.Verbose("This is a Verbose message");
+Log.Debug("This is a Debug message");
+Log.Information("This is an Information message");
+Log.Warning("This is a Warning message");
+Log.Error("This is an Error message");
+Log.Fatal("This is a Fatal message");
 
 
-/* Example exception with stacktrce */
-// try
-// {
-//     throw new Exception("Example exception thrown");
-// }
-// catch (Exception e)
-// {
-//     Log.Error(e, "This is an Error message with an Exception passed in");
-// }
+/* Example exception with stacktrace */
+try
+{
+    throw new Exception("Example exception thrown");
+}
+catch (Exception e)
+{
+    Log.Error(e, "This is an Error message with an Exception passed in");
+}
 
 
 /* Async wrapper behaviour */
 /* should log very fast on console while discord will get it later */
-// for (int i = 0; i < 5; ++i)
-// {
-//     Log.Information($"{i}");
-// }
+for (int i = 0; i < 5; ++i)
+{
+    Log.Information("Count: {Count}", i);
+}
 
 
 /* Long message example */
-// var token = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 !@#$%^&*()_+{}:l',./<>?~`\n";
+const string token = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 !@#$%^&*()_+{}:l',./<>?~`\n";
 
-// var longMessageBuilder = new StringBuilder();
+var longMessageBuilder = new StringBuilder();
 
-// for (var i = 0; i < 100; ++i)
-//     longMessageBuilder.Append(token);
+for (var i = 0; i < 100; ++i)
+    longMessageBuilder.Append(token);
 
-// Console.WriteLine($"Sending message with size: {longMessageBuilder.Length}");
+Console.WriteLine($"Sending message with size: {longMessageBuilder.Length}");
 
-// var longMessage = longMessageBuilder.ToString();
+var longMessage = longMessageBuilder.ToString();
 
-// Log.Information(longMessage);
+Log.Information("{LongMessage}", longMessage);
 
 
 // Flush all then end program

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Serilog.Sinks.Discord
 
-A Serilog sink that writes log events to a Discord channel via Discord Webhooks. The log events will be shown as an embed in the Discord channel.
+A Serilog sink that writes log events to a Discord channel via Discord Webhooks. The log events will be shown as an
+embed in the Discord channel.
 
 ### Getting started
 
-To use the Discord sink, first install the [NuGet package](https://www.nuget.org/packages/Stein121.Serilog.Sinks.Discord)
+To use the Discord sink, first install
+the [NuGet package](https://www.nuget.org/packages/Stein121.Serilog.Sinks.Discord)
 
 ```shell
 dotnet add package Stein121.Serilog.Sinks.Discord
@@ -61,7 +63,10 @@ catch (Exception e)
 ![Exception log](https://raw.githubusercontent.com/stein212/serilog-sinks-discord/master/assets/exception-log.png)
 
 ### Batch logging
-The Discord sink by default sends 1 message with as many embeds as possible (max 10) every 2 seconds. The `batchTimeMs` can be configured to be 0 to send immediately. Do note that spamming the Discord webhook too fast will cause the overall logging to slow down, it is better to send in batches to stay below the Discord rate limits.
+
+The Discord sink by default sends 1 message with as many embeds as possible (max 10) every 2 seconds. The `batchTimeMs`
+can be configured to be 0 to send immediately. Do note that spamming the Discord webhook too fast will cause the overall
+logging to slow down, it is better to send in batches to stay below the Discord rate limits.
 
 ```csharp
 Log.Logger = new Logger Configuration()
@@ -70,7 +75,10 @@ Log.Logger = new Logger Configuration()
 ```
 
 ### Usage with Async Wrapper
-It takes awhile for the Discord sink to send the log to Discord channel. In some cases it might be better to wrap it with `Serilog.Sinks.Async` so that your program does not wait for the log message to reach discord (kind of 'log and forget').
+
+It takes awhile for the Discord sink to send the log to Discord channel. In some cases it might be better to wrap it
+with `Serilog.Sinks.Async` so that your program does not wait for the log message to reach discord (kind of 'log and
+forget').
 
 ```shell
 dotnet add package Serilog.Sinks.Console
@@ -97,7 +105,12 @@ Log.CloseAndFlush();
 ```
 
 ### Long log messages
-The sink is designed to send the log messages as embeds in Discord channels. As of this writing, the limit for the embed's description is `4096`. 
-See [https://discord.com/developers/docs/resources/channel#embed-limits](https://discord.com/developers/docs/resources/channel#embed-limits) for more limits.
 
-The sink will split a long message (>`4096` characters) into multiple embed messages. It will try to first split at a newline `'\n'`, then try to split at a space `' '`, then finally it resorts to breaking the word to fit the embed limits.
+The sink is designed to send the log messages as embeds in Discord channels. As of this writing, the limit for the
+embed's description is `4096`.
+See [https://discord.com/developers/docs/resources/channel#embed-limits](https://discord.com/developers/docs/resources/channel#embed-limits)
+for more limits.
+
+The sink will split a long message (>`4096` characters) into multiple embed messages. It will try to first split at a
+newline `'\n'`, then try to split at a space `' '`, then finally it resorts to breaking the word to fit the embed
+limits.

--- a/Serilog.Sinks.Discord/Serilog.Sinks.Discord.csproj
+++ b/Serilog.Sinks.Discord/Serilog.Sinks.Discord.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.2.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Discord.Net.Webhook" Version="3.7.2" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../README.md" Pack="true" PackagePath="/"/>
+    <None Include="../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/Serilog.Sinks.Discord/Serilog.Sinks.Discord.csproj
+++ b/Serilog.Sinks.Discord/Serilog.Sinks.Discord.csproj
@@ -1,29 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <PackageId>Stein121.Serilog.Sinks.Discord</PackageId>
-    <Version>1.1.1</Version>
-    <Authors>Stein121</Authors>
-    <Copyright>Copyright (c) Stein121 2022-Present</Copyright>
-    <Description>A Serilog sink that writes log events to Discord via Discord Webhook.</Description>
-    <PackageProjectUrl>https://github.com/stein212/serilog-sinks-discord</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/stein212/serilog-sinks-discord</RepositoryUrl>
-    <RespositoryType>git</RespositoryType>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>serilog, logging, log, discord, discord webhook, sink</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>Stein121.Serilog.Sinks.Discord</PackageId>
+        <Version>1.1.1</Version>
+        <Authors>Stein121</Authors>
+        <Copyright>Copyright (c) Stein121 2022-Present</Copyright>
+        <Description>A Serilog sink that writes log events to Discord via Discord Webhook.</Description>
+        <PackageProjectUrl>https://github.com/stein212/serilog-sinks-discord</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/stein212/serilog-sinks-discord</RepositoryUrl>
+        <RespositoryType>git</RespositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageTags>serilog, logging, log, discord, discord webhook, sink</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.7.2" />
-    <PackageReference Include="Serilog" Version="2.11.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Discord.Net.Webhook" Version="3.7.2"/>
+        <PackageReference Include="Serilog" Version="2.11.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="../README.md" Pack="true" PackagePath="/" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="../README.md" Pack="true" PackagePath="/"/>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The latest version of `Discord.Net.Webhooks` kept throwing an exception every time Serilog tried to create the logger.

My Stack Trace when calling `LoggerConfiguration().CreateLogger()`:
```
/home/aidanp/Documents/dotnet/DnDOmegaBot/DndOmegaBot.Console/bin/Debug/net6.0/DndOmegaBot.Console
Unhandled exception. System.AggregateException: One or more errors occurred. (Method not found: 'System.Threading.Tasks.Task`1<UInt64> Discord.Webhook.DiscordWebhookClient.SendMessageAsync(System.String, Boolean, System.Collections.Generic.IEnumerable`1<Discord.Embed>, System.String, System.String, Discord.RequestOptions, Discord.AllowedMentions, Discord.MessageComponent)'.)
 ---> System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task`1<UInt64> Discord.Webhook.DiscordWebhookClient.SendMessageAsync(System.String, Boolean, System.Collections.Generic.IEnumerable`1<Discord.Embed>, System.String, System.String, Discord.RequestOptions, Discord.AllowedMentions, Discord.MessageComponent)'.
   at Serilog.Sinks.Discord.DiscordSink.SendBatchAsync()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Serilog.Sinks.Discord.DiscordSink.SendBatchAsync()
   at Serilog.Sinks.Discord.DiscordSink.EmitAsync(LogEvent logEvent, Boolean timerElapsed)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Serilog.Sinks.Discord.DiscordSink.BatchWaitHelper.SendBatch(Object _)
   at System.Threading.TimerQueueTimer.<>c.<.cctor>b__27_0(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.TimerQueueTimer.CallCallback(Boolean isThreadPool)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.TimerQueue.FireNextTimers()
   at System.Threading.TimerQueue.AppDomainTimerCallback(Int32 id)

Process finished with exit code 134.
```

Taking the key part:
```
System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task`1<UInt64> Discord.Webhook.DiscordWebhookClient.SendMessageAsync(System.String, Boolean, System.Collections.Generic.IEnumerable`1<Discord.Embed>, System.String, System.String, Discord.RequestOptions, Discord.AllowedMentions, Discord.MessageComponent)'.
   at Serilog.Sinks.Discord.DiscordSink.SendBatchAsync()
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Serilog.Sinks.Discord.DiscordSink.SendBatchAsync()
   at Serilog.Sinks.Discord.DiscordSink.EmitAsync(LogEvent logEvent, Boolean timerElapsed)
```

Updating the dependency to the latest version works fine.

Rider was also flagging a bunch of typos, so I corrected those too.